### PR TITLE
Expand CH32V00x device info YAML

### DIFF
--- a/devices/0x21-CH32V00x.yaml
+++ b/devices/0x21-CH32V00x.yaml
@@ -7,9 +7,75 @@ support_usb: false
 support_serial: true
 description: CH32V00x (RISC-V2A) Series
 config_registers:
+  # Ref: section "16.5 User Option Bytes" of RM manual
+  - offset: 0x00
+    name: RDPR_USER
+    description: RDPR, nRDPR, USER, nUSER
+    reset: 0x08F75AA5
+    type: u32
+    fields:
+      - bit_range: [7, 0]
+        name: RDPR
+        description: Read Protection. 0xA5 for unprotected, otherwise read-protected (ignoring WRP)
+        explaination:
+          0xa5: Unprotected
+          _: Protected
+      - bit_range: [16, 16]
+        name: IWDG_SW
+        description: Independent watchdog (IWDG) hardware enable
+        explaination:
+          1: IWDG enabled by software, and not enabled by hardware
+          0: IWDG enabled by hardware (along with the LSI clock)
+      - bit_range: [18, 18]
+        name: STANDBY_RST
+        description: System reset control under the standby mode
+        explaination:
+          1: Disabled, entering standby-mode without RST
+          0: Enabled
+      - bit_range: [20, 19]
+        name: RST_MODE
+        description: External pin PD7 reset mode
+        explaination:
+          0b00: Ignoring pin states within 128us after turning on the multiplexing function
+          0b01: Ignoring pin states within 1ms after turning on the multiplexing function
+          0b10: Ignoring pin states within 12ms after turning on the multiplexing function
+          0b11: Multiplexing function off, PD7 for I/O function
+      - bit_range: [21, 21]
+        name: START_MODE
+        description: Power-on startup mode
+        explaination:
+          1: Start from BOOT area
+          0: Start from user CODE area
+  - offset: 0x04
+    name: DATA
+    description: Customizable 2 byte data, DATA0, nDATA0, DATA1, nDATA1
+    reset: 0xFF00FF00
+    type: u32
+    fields:
+      - bit_range: [7, 0]
+        name: DATA0
+      - bit_range: [23, 16]
+        name: DATA1
+  - offset: 0x08
+    name: WRPR
+    # Each bit is used to control the write-protect status of 1 sector (1K bytes/sector)
+    description: Flash memory write protection status
+    type: u32
+    reset: 0xFFFFFFFF
+    explaination:
+      0xFFFFFFFF: Unprotected
+      _: Some 1K sections are protected
 variants:
-  - name: CH32V003*4*6
-    chip_id: 51
-    alt_chip_ids: [50, 49, 48]
+  - name: CH32V003F4P6
+    chip_id: 0x30
     flash_size: 16K
-
+  - name: CH32V003F4U6
+    chip_id: 0x31
+    flash_size: 16K
+  - name: CH32V003A4M6
+    chip_id: 0x32
+    flash_size: 16K
+  - name: CH32V003J4M6
+    chip_id: 0x33
+    flash_size: 16K
+  # TODO: add CH32V002, 004 & 006 - chip IDs unknown at present


### PR DESCRIPTION
Submitting a PR against your fork so that it can be included as part of PR #56 on main repo, as the two sets of changes go together I think. :)

I've updated the `devices/0x21-CH32V00x.yaml` file to add appropriate `config_registers` data so the option bytes are shown for an 'info' command, and also expanded the device `variants` to each specific model of CH32V003 chip.

```
18:20:30 [INFO] Chip: CH32V003F4P6[0x3021] (Code Flash: 16KiB)
18:20:30 [INFO] Chip UID: CD-AB-35-23-48-BC-4A-8B
18:20:30 [INFO] BTVER(bootloader ver): 02.30
18:20:30 [INFO] Current config registers: a55af708ff00ff00ffffffff00020300cdab352348bc4a8b
RDPR_USER: 0x08F75AA5
  [7:0]   RDPR 0xA5 (0b10100101)
    `- Unprotected
  [16:16] IWDG_SW 0x1 (0b1)
    `- IWDG enabled by software, and not enabled by hardware
  [18:18] STANDBY_RST 0x1 (0b1)
    `- Disabled, entering standby-mode without RST
  [20:19] RST_MODE 0x2 (0b10)
    `- Ignoring pin states within 12ms after turning on the multiplexing function
  [21:21] START_MODE 0x1 (0b1)
    `- Start from BOOT area
DATA: 0x00FF00FF
  [7:0]   DATA0 0xFF (0b11111111)
  [23:16] DATA1 0xFF (0b11111111)
WRPR: 0xFFFFFFFF
  `- Unprotected
```

Couldn't find out any info on what the chip IDs are for new '002, '004, and '006, so that'll have to wait for the future.